### PR TITLE
Ap 378/package improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+### 1.0.2 - 2015-08-18
+
+* Bug fixes
+
+### 1.0.1 - 2015-08-05
+
+* Bug fixes
+
+### 1.0.0 - 2015-07-31
+
+* Upgrade to use v3 of Quandl API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quandl (1.0.2rc1)
+    quandl (1.0.2)
       activesupport (>= 4.2.3)
       json (~> 1.8.3)
       rest-client (~> 1.8.0)
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.3)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -102,4 +102,4 @@ DEPENDENCIES
   webmock (~> 1.21.0)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quandl (1.0.1)
+    quandl (1.0.2rc1)
       activesupport (>= 4.2.3)
       json (~> 1.8.3)
       rest-client (~> 1.8.0)
@@ -36,7 +36,7 @@ GEM
     json (1.8.3)
     method_source (0.8.2)
     mime-types (2.6.1)
-    minitest (5.7.0)
+    minitest (5.8.0)
     netrc (0.10.3)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
@@ -67,7 +67,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    rubocop (0.32.1)
+    rubocop (0.33.0)
       astrolabe (~> 1.3)
       parser (>= 2.2.2.5, < 3.0)
       powerpack (~> 0.1)

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Quandl::Database.all
 => ... results ...
 ```
 
-### Database Bulk Download
+### Download Entire Database (Bulk Download)
 
-To get the url for bulk download of all datasets data of a database:
+To get the url for downloading all dataset data of a database:
 
 ```ruby
 require 'quandl'
@@ -95,19 +95,21 @@ Quandl::Database.get('ZEA').bulk_download_url
 => "https://www.quandl.com/api/v3/databases/ZEA/data?api_key=tEsTkEy123456789"
 ```
 
-To bulk download all datasets data of a database:
+To bulk download all dataset data of a database:
 
 ```ruby
 Quandl::ApiConfig.api_key = 'tEsTkEy123456789'
 Quandl::Database.get('ZEA').bulk_download_to_file('/path/to/destination/file_or_folder')
 ```
 
+The file or folder path can either be specified as a string or as a [File](http://ruby-doc.org/core-2.2.0/File.html).
+
 For bulk download of premium databases, please ensure that a valid `api_key` is set, as authentication is required.
 
-For both `bulk_download_url` and `bulk_download_to_file`, an optional `download_type` parameter can be passed in:
+For both `bulk_download_url` and `bulk_download_to_file`, an optional `download_type` query parameter can be passed in:
 
 ```ruby
-Quandl::Database.get('ZEA').bulk_download_to_file('.', download_type: 'partial')
+Quandl::Database.get('ZEA').bulk_download_to_file('.', params: {download_type: 'partial'})
 ```
 
 If `download_type` is not specified, a `complete` bulk download will be performed. Please see the [API Documentation](https://www.quandl.com/docs/api) for more detail.

--- a/lib/quandl/errors/quandl_error.rb
+++ b/lib/quandl/errors/quandl_error.rb
@@ -53,4 +53,7 @@ module Quandl
 
   class ForbiddenError < QuandlError
   end
+
+  class InvalidDataError < QuandlError
+  end
 end

--- a/lib/quandl/model/data.rb
+++ b/lib/quandl/model/data.rb
@@ -3,6 +3,11 @@ module Quandl
     include Quandl::Operations::List
 
     def self.create_list_from_response(_response, data)
+      if data['dataset_data']['data'].length > 0 &&
+         data['dataset_data']['column_names'].length != data['dataset_data']['data'].first.length
+        fail InvalidDataError.new('number of column names does not match number of data points in a row!',
+                                  nil, nil, data)
+      end
       values = data['dataset_data'].delete('data')
       metadata = data['dataset_data']
       Quandl::List.new(self, values, metadata)

--- a/lib/quandl/version.rb
+++ b/lib/quandl/version.rb
@@ -1,3 +1,3 @@
 module Quandl
-  VERSION = '1.0.2rc1'
+  VERSION = '1.0.2'
 end

--- a/lib/quandl/version.rb
+++ b/lib/quandl/version.rb
@@ -1,3 +1,3 @@
 module Quandl
-  VERSION = '1.0.1'
+  VERSION = '1.0.2rc1'
 end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -113,7 +113,7 @@ describe 'Connection' do
     let(:expected_headers) do
       {
         request_source: 'ruby',
-        request_source_version: '1.0.2rc1',
+        request_source_version: '1.0.2',
         accept: 'application/json, application/vnd.quandl+json;version=2015-04-09',
         x_api_token: 'api_token',
         foo_bar: 'foo bar'

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -113,7 +113,7 @@ describe 'Connection' do
     let(:expected_headers) do
       {
         request_source: 'ruby',
-        request_source_version: '1.0.1',
+        request_source_version: '1.0.2rc1',
         accept: 'application/json, application/vnd.quandl+json;version=2015-04-09',
         x_api_token: 'api_token',
         foo_bar: 'foo bar'

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -42,16 +42,18 @@ describe 'Database' do
     context 'bulk_download_url' do
       before(:each) do
         Quandl::ApiConfig.api_key = 'token'
+        Quandl::ApiConfig.api_version = '2015-04-09'
       end
       it 'constructs the url' do
-        expect(database_instance.bulk_download_url(download_type: 'partial'))
-          .to eq("https://www.quandl.com/api/v3/databases/#{database[:database][:database_code]}/data?api_key=token&download_type=partial")
+        expect(database_instance.bulk_download_url(params: { download_type: 'partial' }))
+          .to eq("https://www.quandl.com/api/v3/databases/#{database[:database][:database_code]}/data?api_key=token&api_version=2015-04-09&download_type=partial")
       end
     end
 
     context 'bulk_download_to_file' do
       before(:each) do
         Quandl::ApiConfig.api_key = 'token'
+        Quandl::ApiConfig.api_version = nil
         stub_request(:any, %r{https://www.quandl.com/.*}).to_return(headers: { 'Location' => 'https://www.blah.com/download/database' }, status: 302)
       end
 
@@ -73,7 +75,7 @@ describe 'Database' do
 
       context 'with 302 return' do
         it 'parses download url from header and download file' do
-          expect(database_instance).to receive(:bulk_download_url).with(path_only: true).and_return('https://www.quandl.com/download')
+          expect(database_instance).to receive(:bulk_download_path).and_return('/download')
           http = Net::HTTP.new('www.blah.com', 443)
           file_object = double('file')
           expect(File).to receive(:open).and_return(file_object)
@@ -82,7 +84,7 @@ describe 'Database' do
           expect(http).to receive(:request_get)
           expect(Net::HTTP).to receive(:new).with('www.quandl.com', 443).and_call_original
           expect(Net::HTTP).to receive(:new).with('www.blah.com', 443).and_return(http)
-          database_instance.bulk_download_to_file('.')
+          database_instance.bulk_download_to_file('.', params: { download_type: 'partial' })
         end
       end
     end


### PR DESCRIPTION
Tracker Ticket:
https://quandl.atlassian.net/browse/AP-378
https://quandl.atlassian.net/browse/AP-291

## Description:  
* Check for data integrity when fetching dataset data: if the # column names does not match the number of data columns, throw an error
* Bulk download shoul get its query parameters from params, like other methods. This allows us to be more flexible with api versioning, as the package does not expect a specific param name to be passed in
* Allow bulk download to accept a file path as a string (before only a folder path was allowed)
* Update tests to reflect changes
* Update README to reflect changes

## Note to the reviewer:


## Note to QA:

