### PR TITLE
Remove thread restrictions for configuration

### DIFF
--- a/lib/quandl/api_config.rb
+++ b/lib/quandl/api_config.rb
@@ -1,32 +1,32 @@
 module Quandl
   class ApiConfig
-    API_KEY_THREAD_KEY = 'quandl_api_key'
-    API_BASE_THREAD_KEY = 'quandl_api_base'
-    API_VERSION_THREAD_KEY = 'quandl_api_version_key'
+    @@api_key = nil
+    @@api_base = 'https://www.quandl.com/api/v3'
+    @@api_version = nil
 
     class << self
       def api_key=(api_key)
-        Thread.current[API_KEY_THREAD_KEY] = api_key
+        @@api_key = api_key
       end
 
       def api_key
-        Thread.current[API_KEY_THREAD_KEY]
+        @@api_key
       end
 
       def api_base=(api_base)
-        Thread.current[API_BASE_THREAD_KEY] = api_base
+        @@api_base = api_base
       end
 
       def api_base
-        Thread.current[API_BASE_THREAD_KEY] || 'https://www.quandl.com/api/v3'
+        @@api_base
       end
 
       def api_version=(api_version)
-        Thread.current[API_VERSION_THREAD_KEY] = api_version
+        @@api_version = api_version
       end
 
       def api_version
-        Thread.current[API_VERSION_THREAD_KEY]
+        @@api_version
       end
     end
   end


### PR DESCRIPTION
I use Quandl together with sidekiq and the jobs do not pick up on the `api_key` set in the initializer. Using class variables solved it for me, but maybe you have a reason for using thread-based variables.