### PR TITLE
Allow for config defaults when working in a forked/threaded environment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.3 - 2015-09-16
+
+* Add in better support for threaded environments that spawn main code after the api-key has been set.
+
 ### 1.0.2 - 2015-08-18
 
 * Bug fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quandl (1.0.2)
+    quandl (1.0.3)
       activesupport (>= 4.2.3)
       json (~> 1.8.3)
       rest-client (~> 1.8.0)
@@ -35,7 +35,7 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     method_source (0.8.2)
-    mime-types (2.6.1)
+    mime-types (2.6.2)
     minitest (5.8.0)
     netrc (0.10.3)
     parser (2.2.2.6)
@@ -67,7 +67,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    rubocop (0.33.0)
+    rubocop (0.34.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.2.5, < 3.0)
       powerpack (~> 0.1)

--- a/lib/quandl/api_config.rb
+++ b/lib/quandl/api_config.rb
@@ -4,29 +4,42 @@ module Quandl
     API_BASE_THREAD_KEY = 'quandl_api_base'
     API_VERSION_THREAD_KEY = 'quandl_api_version_key'
 
+    @api_key = nil
+    @api_base = nil
+    @api_version = nil
+
     class << self
       def api_key=(api_key)
+        @api_key = api_key if @api_key.nil?
         Thread.current[API_KEY_THREAD_KEY] = api_key
       end
 
       def api_key
-        Thread.current[API_KEY_THREAD_KEY]
+        Thread.current[API_KEY_THREAD_KEY] || @api_key
       end
 
       def api_base=(api_base)
+        @api_base = api_base if @api_base.nil?
         Thread.current[API_BASE_THREAD_KEY] = api_base
       end
 
       def api_base
-        Thread.current[API_BASE_THREAD_KEY] || 'https://www.quandl.com/api/v3'
+        Thread.current[API_BASE_THREAD_KEY] || @api_base || 'https://www.quandl.com/api/v3'
       end
 
       def api_version=(api_version)
+        @api_version = api_base if @api_version.nil?
         Thread.current[API_VERSION_THREAD_KEY] = api_version
       end
 
       def api_version
-        Thread.current[API_VERSION_THREAD_KEY]
+        Thread.current[API_VERSION_THREAD_KEY] || @api_version
+      end
+
+      def reset
+        @api_key = nil
+        @api_base = nil
+        @api_version = nil
       end
     end
   end

--- a/lib/quandl/version.rb
+++ b/lib/quandl/version.rb
@@ -1,3 +1,3 @@
 module Quandl
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/spec/api_config_spec.rb
+++ b/spec/api_config_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe Quandl::ApiConfig do
+  context '.api_base' do
+    it 'defaults to Quandl' do
+      expect(Quandl::ApiConfig.api_base).to eq('https://www.quandl.com/api/v3')
+    end
+  end
+
+  context '.api_key' do
+    it 'is nil by default' do
+      expect(Quandl::ApiConfig.api_key).to be_nil
+    end
+
+    context 'threading' do
+      let(:threads) { [] }
+
+      before(:each) do
+        Quandl::ApiConfig.reset
+      end
+
+      it 'should be nil if a default is not set' do
+        1.times do
+          threads << Thread.new do
+            expect(Quandl::ApiConfig.api_key).to be_nil
+          end
+        end
+
+        threads.map(&:join)
+      end
+
+      it 'allows users to change their settings per thread' do
+        3.times do
+          threads << Thread.new do
+            api_key = (0...8).map { (65 + rand(26)).chr }.join
+            Quandl::ApiConfig.api_key = api_key
+            expect(Quandl::ApiConfig.api_key).to eq(api_key)
+          end
+          sleep(1) # Important to ensure that previous thread code has executed
+        end
+
+        threads.map(&:join)
+      end
+
+      context 'with a default set' do
+        let(:default_key) { (0...8).map { (65 + rand(26)).chr }.join }
+
+        before(:each) do
+          Quandl::ApiConfig.api_key = default_key
+        end
+
+        it 'should allows for a default value' do
+          expect do
+            3.times do
+              threads << Thread.new do
+                expect(Quandl::ApiConfig.api_key).to eq(default_key)
+
+                api_key = (0...8).map { (65 + rand(26)).chr }.join
+                Quandl::ApiConfig.api_key = api_key
+                expect(Quandl::ApiConfig.api_key).to eq(api_key)
+              end
+              sleep(1) # Important to ensure that previous thread code has executed
+            end
+
+            threads.map(&:join)
+          end.not_to change {
+            Quandl::ApiConfig.api_key
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related PR: https://github.com/quandl/quandl-ruby/pull/5

* Allow for setting config variables in a threaded way but also setting a default value for forked processes.