### PR TITLE
Depend on up to date activesupport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 
 install:
   - gem install rubocop
-  - bundle install
+  - bundle update
 
 script:
   - rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,22 @@
 PATH
   remote: .
   specs:
-    quandl (1.0.3)
-      activesupport (~> 4.2.8)
+    quandl (1.0.4)
+      activesupport (>= 4.2.8)
       json (~> 2.1.0)
       rest-client (~> 2.0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.8)
+    activesupport (5.1.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    byebug (9.0.6)
-    coderay (1.1.1)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
@@ -30,19 +29,11 @@ GEM
       domain_name (~> 0.5)
     i18n (0.8.1)
     json (2.1.0)
-    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    minitest (5.10.1)
+    minitest (5.10.2)
     netrc (0.11.0)
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    pry-byebug (3.4.2)
-      byebug (~> 9.0)
-      pry (~> 0.10)
     public_suffix (2.0.5)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
@@ -62,7 +53,6 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     safe_yaml (1.0.4)
-    slop (3.6.0)
     thread_safe (0.3.6)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
@@ -79,10 +69,9 @@ PLATFORMS
 
 DEPENDENCIES
   factory_girl (~> 4.5.0)
-  pry-byebug
   quandl!
   rspec
   webmock (~> 3.0.1)
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/quandl.gemspec
+++ b/quandl.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir['test/**/*']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '~> 4.2.8'
+  spec.add_runtime_dependency 'activesupport', '>= 4.2.8'
   spec.add_runtime_dependency 'rest-client', '~> 2.0.2'
   spec.add_runtime_dependency 'json', '~> 2.1.0'
 

--- a/quandl.gemspec
+++ b/quandl.gemspec
@@ -20,7 +20,12 @@ Gem::Specification.new do |spec|
   spec.test_files = Dir['test/**/*']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 4.2.8'
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.2')
+    spec.add_runtime_dependency 'activesupport', '>= 4.2.8'
+  else
+    spec.add_runtime_dependency 'activesupport', '~> 4.2.8'
+  end
+
   spec.add_runtime_dependency 'rest-client', '~> 2.0.2'
   spec.add_runtime_dependency 'json', '~> 2.1.0'
 


### PR DESCRIPTION
Quandl-ruby works perfectly well with the current `activesupport` (5.1.1).
This relaxes version constraint and allows `quandl-ruby` to be used with the current `rails` version.